### PR TITLE
Replace redis with memory cache

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -9,7 +9,8 @@ This is the .NET backend for the Home Services application, built with ABP Frame
 - **Entity Framework Core** for data access
 - **OpenIddict** for authentication and authorization
 - **SQLite** database (configurable)
-- **Redis** for caching and session management
+- **In-Memory Caching** for application caching
+- **File-based distributed locking** for synchronization
 - **AutoMapper** for object mapping
 - **Swagger/OpenAPI** for API documentation
 
@@ -65,7 +66,6 @@ The solution follows Domain Driven Design (DDD) principles with a layered archit
 ## Prerequisites
 
 - [.NET 9.0+ SDK](https://dotnet.microsoft.com/download/dotnet)
-- [Redis](https://redis.io/) (for caching and session management)
 - SQL Server, PostgreSQL, or SQLite (SQLite is default)
 
 ## Getting Started
@@ -155,9 +155,6 @@ Key configuration files:
       }
     }
   },
-  "Redis": {
-    "Configuration": "localhost:6379"
-  },
   "Settings": {
     "Abp.Mailing.Smtp.Host": "smtp.gmail.com",
     "Abp.Mailing.Smtp.Port": "587",
@@ -244,10 +241,9 @@ abp generate-proxy -t csharp -u https://localhost:44375
 ### Production Configuration
 
 1. **Update connection strings** for production database
-2. **Configure Redis** for production caching
-3. **Set up HTTPS certificates** for secure communication
-4. **Configure email settings** for notifications
-5. **Set up external authentication** providers (Google, Facebook, etc.)
+2. **Set up HTTPS certificates** for secure communication
+3. **Configure email settings** for notifications
+4. **Set up external authentication** providers (Google, Facebook, etc.)
 
 ### Docker Deployment
 
@@ -322,8 +318,7 @@ Logging is configured with Serilog for structured logging:
 ## Performance
 
 ### Caching
-- Redis distributed caching
-- In-memory caching for frequently accessed data
+- In-memory distributed caching for application data
 - HTTP response caching
 - Database query result caching
 
@@ -347,10 +342,10 @@ Logging is configured with Serilog for structured logging:
    - Verify client credentials
    - Ensure HTTPS is properly configured
 
-3. **Redis connection errors**
-   - Verify Redis server is running
-   - Check Redis connection string
-   - Ensure Redis is accessible from application
+3. **Cache or locking issues**
+   - Check that App_Data directory is writable
+   - Verify file-based locking directory permissions
+   - Clear cache files if needed
 
 ### Debugging
 

--- a/backend/src/HomeServicesApp.AuthServer/HomeServicesApp.AuthServer.csproj
+++ b/backend/src/HomeServicesApp.AuthServer/HomeServicesApp.AuthServer.csproj
@@ -42,8 +42,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="9.0.7" />
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="9.0.4" />
-    <PackageReference Include="DistributedLock.Redis" Version="1.0.3" />
+    <PackageReference Include="DistributedLock.FileSystem" Version="1.0.3" />
   </ItemGroup>
 
   <ItemGroup>
@@ -52,7 +51,7 @@
 
   <ItemGroup>
     <PackageReference Include="Volo.Abp.Autofac" Version="9.2.2" />
-    <PackageReference Include="Volo.Abp.Caching.StackExchangeRedis" Version="9.2.2" />
+    <PackageReference Include="Volo.Abp.Caching" Version="9.2.2" />
     <PackageReference Include="Volo.Abp.DistributedLocking" Version="9.2.2" />
     <PackageReference Include="Volo.Abp.AspNetCore.Serilog" Version="9.2.2" />
     <PackageReference Include="Volo.Abp.Account.Web.OpenIddict" Version="9.2.2" />

--- a/backend/src/HomeServicesApp.AuthServer/appsettings.json
+++ b/backend/src/HomeServicesApp.AuthServer/appsettings.json
@@ -11,9 +11,6 @@
   "ConnectionStrings": {
     "Default": "Data Source=/home/ubuntu/HomeServicesApp/HomeServicesApp.db"
   },
-  "Redis": {
-    "Configuration": "127.0.0.1"
-  },
   "Google": {
     "ClientId": "YOUR_GOOGLE_CLIENT_ID",
     "ClientSecret": "YOUR_GOOGLE_CLIENT_SECRET"

--- a/backend/src/HomeServicesApp.DbMigrator/HomeServicesApp.DbMigrator.csproj
+++ b/backend/src/HomeServicesApp.DbMigrator/HomeServicesApp.DbMigrator.csproj
@@ -31,7 +31,7 @@
 
   <ItemGroup>
     <PackageReference Include="Volo.Abp.Autofac" Version="9.2.2" />
-    <PackageReference Include="Volo.Abp.Caching.StackExchangeRedis" Version="9.2.2" />
+    <PackageReference Include="Volo.Abp.Caching" Version="9.2.2" />
     <ProjectReference Include="..\HomeServicesApp.Application.Contracts\HomeServicesApp.Application.Contracts.csproj" />
     <ProjectReference Include="..\HomeServicesApp.EntityFrameworkCore\HomeServicesApp.EntityFrameworkCore.csproj" />
   </ItemGroup>

--- a/backend/src/HomeServicesApp.DbMigrator/HomeServicesAppDbMigratorModule.cs
+++ b/backend/src/HomeServicesApp.DbMigrator/HomeServicesAppDbMigratorModule.cs
@@ -1,14 +1,13 @@
-﻿using HomeServicesApp.EntityFrameworkCore;
+using HomeServicesApp.EntityFrameworkCore;
 using Volo.Abp.Autofac;
 using Volo.Abp.Caching;
-using Volo.Abp.Caching.StackExchangeRedis;
 using Volo.Abp.Modularity;
 
 namespace HomeServicesApp.DbMigrator;
 
 [DependsOn(
     typeof(AbpAutofacModule),
-    typeof(AbpCachingStackExchangeRedisModule),
+    typeof(AbpCachingModule),
     typeof(HomeServicesAppEntityFrameworkCoreModule),
     typeof(HomeServicesAppApplicationContractsModule)
     )]

--- a/backend/src/HomeServicesApp.DbMigrator/appsettings.json
+++ b/backend/src/HomeServicesApp.DbMigrator/appsettings.json
@@ -5,9 +5,6 @@
   "ConnectionStrings": {
     "Default": "Host=localhost;Port=5432;Database=homeservicesapp;Username=postgres;Password=postgres"
   },
-  "Redis": {
-    "Configuration": "127.0.0.1"
-  },
   "OpenIddict": {
     "Applications": {
       "HomeServicesApp_Swagger": {

--- a/backend/src/HomeServicesApp.HttpApi.Host/HomeServicesApp.HttpApi.Host.csproj
+++ b/backend/src/HomeServicesApp.HttpApi.Host/HomeServicesApp.HttpApi.Host.csproj
@@ -18,12 +18,11 @@
     <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="9.0.4" />
-    <PackageReference Include="DistributedLock.Redis" Version="1.0.3" />
+    <PackageReference Include="DistributedLock.FileSystem" Version="1.0.3" />
     <PackageReference Include="Volo.Abp.AspNetCore.Authentication.JwtBearer" Version="9.2.2" />
     <PackageReference Include="Volo.Abp.AspNetCore.Mvc.UI.MultiTenancy" Version="9.2.2" />
     <PackageReference Include="Volo.Abp.Autofac" Version="9.2.2" />
-    <PackageReference Include="Volo.Abp.Caching.StackExchangeRedis" Version="9.2.2" />
+    <PackageReference Include="Volo.Abp.Caching" Version="9.2.2" />
     <PackageReference Include="Volo.Abp.DistributedLocking" Version="9.2.2" />
     <PackageReference Include="Volo.Abp.AspNetCore.Serilog" Version="9.2.2" />
     <PackageReference Include="Volo.Abp.Swashbuckle" Version="9.2.2" />

--- a/backend/src/HomeServicesApp.HttpApi.Host/appsettings.json
+++ b/backend/src/HomeServicesApp.HttpApi.Host/appsettings.json
@@ -8,9 +8,6 @@
   "ConnectionStrings": {
     "Default": "Data Source=/home/ubuntu/HomeServicesApp/HomeServicesApp.db"
   },
-  "Redis": {
-    "Configuration": "127.0.0.1"
-  },
   "AuthServer": {
     "Authority": "https://localhost:44322",
     "RequireHttpsMetadata": true,


### PR DESCRIPTION
Replace Redis with in-memory caching and file-based alternatives to remove the Redis dependency.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d199c3c-ff6e-488e-b95e-333891158157">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3d199c3c-ff6e-488e-b95e-333891158157">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

