### PR TITLE
Deploy to free host via ci cd

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,34 @@
+services:
+  - type: web
+    name: homeservices-api
+    env: docker
+    plan: free
+    dockerfilePath: backend/Dockerfile
+    autoDeploy: true
+    healthCheckPath: /
+    envVars:
+      - key: Database__Provider
+        value: PostgreSql
+      - key: ConnectionStrings__Default
+        fromSecret: PG_CONN_STR
+      - key: App__CorsOrigins
+        fromSecret: APP_CORS_ORIGINS
+
+  - type: web
+    name: homeservices-auth
+    env: docker
+    plan: free
+    dockerfilePath: backend/AuthServer.Dockerfile
+    autoDeploy: true
+    healthCheckPath: /health
+    envVars:
+      - key: Database__Provider
+        value: PostgreSql
+      - key: ConnectionStrings__Default
+        fromSecret: PG_CONN_STR
+      - key: App__SelfUrl
+        fromSecret: AUTH_SELF_URL
+      - key: App__ClientUrl
+        fromSecret: AUTH_CLIENT_URL
+      - key: App__CorsOrigins
+        fromSecret: AUTH_CORS_ORIGINS


### PR DESCRIPTION
Add `render.yaml` to enable backend deployment to Render's free tier.

---
<a href="https://cursor.com/background-agent?bcId=bc-d40a7baf-fed3-4e8b-9e9d-fef9ce1f9578">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d40a7baf-fed3-4e8b-9e9d-fef9ce1f9578">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

