### PR TITLE
Fix ReviewStatus enum namespace in ReviewController

### DIFF
--- a/backend/src/HomeServicesApp.HttpApi/Controllers/ReviewController.cs
+++ b/backend/src/HomeServicesApp.HttpApi/Controllers/ReviewController.cs
@@ -117,7 +117,7 @@ namespace HomeServicesApp.Controllers
 
     public class ModerateReviewDto
     {
-        public ReviewStatus Status { get; set; }
+        public HomeServicesApp.Reviews.ReviewStatus Status { get; set; }
         public string Notes { get; set; }
     }
 


### PR DESCRIPTION
Explicitly qualify ReviewStatus as HomeServicesApp.Reviews.ReviewStatus in ModerateReviewDto to match the IReviewAppService.ModerateAsync method signature. 
 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>This pull request addresses a bug by explicitly qualifying the ReviewStatus enum in the ModerateReviewDto class.</li>

<li>This change ensures consistency with the method signature of IReviewAppService.ModerateAsync.</li>

<li>The modification improves the clarity and correctness of the code, aligning it with the expected usage.</li>

<li>Overall, this pull request addresses a bug in the ModerateReviewDto class and aligns it with the IReviewAppService.ModerateAsync method.</li>

</ul>

</div>